### PR TITLE
Cleaner and leaner docker github runner to be used for kubernetes deployments, closes #25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build_push_image:
     name: Building and storing PhotoAtom Runner Docker Image
-    uses: PhotoAtom/automations/.github/workflows/build-docker-image.yml@bug/24/secrets
+    uses: PhotoAtom/automations/.github/workflows/build-docker-image.yml@main
     with:
       dev_version_name: development
       image_name: runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,13 @@ on:
 jobs:
   build_push_image:
     name: Building and storing PhotoAtom Runner Docker Image
-    uses: PhotoAtom/automations/.github/workflows/build-docker-image.yml@main
+    uses: PhotoAtom/automations/.github/workflows/build-docker-image.yml@bug/24/secrets
     with:
       dev_version_name: development
       image_name: runner
       image_proper_name: PhotoAtom Runner
       build_path: .
       repository: necronizerslab
-    secrets: inherit
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,3 @@ jobs:
       - name: Run KubeCTL Commands to check communication with the local K3d cluster
         run: |
           kubectl get ns
-
-      - name: Check if OpenTofu is installed or not
-        run: tofu --version
-
-      - name: Check for packages installed
-        run: |
-          echo "KubeCTL CNPG Plugin: $(kubectl cnpg version)"
-          echo "MinIO CLI: $(mc --version)"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN apt install -y --no-install-recommends \
   libicu-dev \
   apt-transport-https \
   ca-certificates \
-  gnupg \
-  openjdk-21-jdk
+  gnupg
 
 # Installing kubectl
 RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
@@ -44,8 +43,6 @@ RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key | gpg --d
   apt install -y kubectl
 
 # Installing the CNPG Plugin
-RUN wget https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.25.0/kubectl-cnpg_1.25.0_linux_x86_64.deb  && \
-  dpkg -i kubectl-cnpg_1.25.0_linux_x86_64.deb
 
 # Installing OpenTofu
 RUN install -m 0755 -d /etc/apt/keyrings && \
@@ -59,11 +56,6 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
   chmod a+r /etc/apt/sources.list.d/opentofu.list && \
   apt update && \
   apt install -y tofu
-
-# Installing MinIO CLI
-RUN curl https://dl.min.io/client/mc/release/linux-amd64/mc \
-  -o /usr/local/bin/mc && \
-  chmod +x /usr/local/bin/mc
 
 # Download the runner package and extract it
 RUN cd /home/docker && mkdir actions-runner && cd actions-runner && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,8 @@ RUN apt install -y --no-install-recommends \
   gnupg
 
 # Installing kubectl
-RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
-  chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
-  echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list && \
-  chmod 644 /etc/apt/sources.list.d/kubernetes.list && \
-  apt update && \
-  apt install -y kubectl
-
-# Installing the CNPG Plugin
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+  install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # Installing OpenTofu
 RUN install -m 0755 -d /etc/apt/keyrings && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   runners:
-    image: quay.io/necronizerslab/runner:0.23.24
+    image: quay.io/necronizerslab/runner:0.25.26
     env_file:
       - runner.env
     networks:
@@ -10,4 +10,3 @@ networks:
   k3d_network:
     name: k3d-photoatom
     external: true
-


### PR DESCRIPTION
# Changes:
 - Removal of CNPG Plugin and MinIO CLI tool
 - KubeCTL CLI installation overhaul, latest versions picked at every build
 - Docker build pipeline fixes
 - Kubernetes communication pipeline updated to reflect updated packages list